### PR TITLE
HCF-732 recursively do template expansion for ((env))

### DIFF
--- a/lib/environment_config_transmogrifier.rb
+++ b/lib/environment_config_transmogrifier.rb
@@ -25,7 +25,7 @@ module EnvironmentConfigTransmogrifier
     extendReplace(input_hash, secrets) if secrets && File.directory?(secrets)
 
     # remove empty values
-    input_hash.reject! { |k, v| v.nil? || v.empty? }
+    input_hash.reject! { |_, v| v.nil? || v.empty? }
 
     # iterate through templates
     environment_templates.each do |key, value|
@@ -58,7 +58,7 @@ module EnvironmentConfigTransmogrifier
       # means that the values found in 'path' have priority over the
       # values already in the 'hash'. This is what we want for
       # '/etc/secrets'
-      hash[key.upcase.gsub('-','_')] = value
+      hash[key.upcase.tr('-', '_')] = value
     end
   end
 

--- a/spec/lib/environment_config_transmogrifier_spec.rb
+++ b/spec/lib/environment_config_transmogrifier_spec.rb
@@ -54,7 +54,7 @@ describe EnvironmentConfigTransmogrifier do
       environment_templates = {
         'properties.parent_key.child_key.grandchild_key' => '((MY_FOO_VAR))'
       }
-      ENV['MY_FOO_VAR'] = 'bar'
+      expect(ENV).to receive(:to_hash).and_return('MY_FOO_VAR' => 'bar')
 
       # Act
       new_config = EnvironmentConfigTransmogrifier.transmogrify(@base_config, environment_templates)
@@ -68,7 +68,7 @@ describe EnvironmentConfigTransmogrifier do
       environment_templates = {
         'properties.parent_key.child_key.grandchild_key' => '((MY_FOO_VAR))'
       }
-      ENV['MY_FOO_VAR'] = '0'
+      expect(ENV).to receive(:to_hash).and_return('MY_FOO_VAR' => '0')
 
       # Act
       new_config = EnvironmentConfigTransmogrifier.transmogrify(@base_config, environment_templates)
@@ -83,7 +83,7 @@ describe EnvironmentConfigTransmogrifier do
       environment_templates = {
         'properties.parent_key.child_key.grandchild_key' => "'((MY_FOO_VAR))'"
       }
-      ENV['MY_FOO_VAR'] = '0'
+      expect(ENV).to receive(:to_hash).and_return('MY_FOO_VAR' => '0')
 
       # Act
       new_config = EnvironmentConfigTransmogrifier.transmogrify(@base_config, environment_templates)
@@ -98,7 +98,7 @@ describe EnvironmentConfigTransmogrifier do
       environment_templates = {
         'properties.parent_key.child_key.grandchild_key' => '((MY_FOO_VAR))'
       }
-      ENV['MY_FOO_VAR'] = 'bar'
+      expect(ENV).to receive(:to_hash).and_return('MY_FOO_VAR' => 'bar')
 
       Dir.mktmpdir do |secrets|
         f = File.new(File.join(secrets, 'MY_FOO_VAR'), 'w')
@@ -116,7 +116,7 @@ describe EnvironmentConfigTransmogrifier do
 
     it 'should ignore a secrets file' do
       # Arrange
-      allow(EnvironmentConfigTransmogrifier).to receive (:extendReplace) {}
+      allow(EnvironmentConfigTransmogrifier).to receive(:extendReplace) {}
       environment_templates = {}
 
       Dir.mktmpdir do |tmp|
@@ -135,7 +135,7 @@ describe EnvironmentConfigTransmogrifier do
 
     it 'should ignore a nil secrets' do
       # Arrange
-      allow(EnvironmentConfigTransmogrifier).to receive (:extendReplace) {}
+      allow(EnvironmentConfigTransmogrifier).to receive(:extendReplace) {}
       environment_templates = {}
 
       # Act
@@ -146,10 +146,7 @@ describe EnvironmentConfigTransmogrifier do
     end
 
     it 'should recursively resolve subtitutions' do
-      expect(ENV).to receive(:to_hash).and_return(
-        'FOO' => '((BAR))',
-        'BAR' => 'bbb'
-      )
+      expect(ENV).to receive(:to_hash).and_return('FOO' => '((BAR))', 'BAR' => 'bbb')
 
       environment_templates = {
         'properties.key' => 'aaa((FOO))ccc'

--- a/spec/lib/environment_config_transmogrifier_spec.rb
+++ b/spec/lib/environment_config_transmogrifier_spec.rb
@@ -144,5 +144,20 @@ describe EnvironmentConfigTransmogrifier do
       # Asserts
       expect(EnvironmentConfigTransmogrifier).to receive(:extendReplace).exactly(0).times
     end
+
+    it 'should recursively resolve subtitutions' do
+      expect(ENV).to receive(:to_hash).and_return(
+        'FOO' => '((BAR))',
+        'BAR' => 'bbb'
+      )
+
+      environment_templates = {
+        'properties.key' => 'aaa((FOO))ccc'
+      }
+
+      new_config = EnvironmentConfigTransmogrifier.transmogrify(@base_config, environment_templates)
+
+      expect(new_config['properties']['key']).to eq 'aaabbbccc'
+    end
   end
 end


### PR DESCRIPTION
This will cause any of the mustache templates we encounter to be re-evaluated if the result looks like another template.  For now this is defined as having the literal string '((' somewhere in the output.

This is needed because we want to use `UAA_HOST` but we actually get something named `HCP_IDENTITY_HOST` instead (and various related pieces like `HCP_IDENTITY_PORT`).
