### PR TITLE
Adding preservation of new line characters in transmogrifier

### DIFF
--- a/lib/environment_config_transmogrifier.rb
+++ b/lib/environment_config_transmogrifier.rb
@@ -32,7 +32,10 @@ module EnvironmentConfigTransmogrifier
       # generate value from template
       while value.respond_to?(:include?) && value.include?('((')
         begin
-          value = YAML.load(NoEscapeMustache.render("{{=(( ))=}}#{value}", input_hash))
+          mustache_value=NoEscapeMustache.render("{{=(( ))=}}#{value}", input_hash)
+          # replace new lines with double new lines for proper new-line YAML parsing
+          mustache_value=mustache_value.gsub("\n", "\n\n")
+          value = YAML.load(mustache_value)
         rescue => e
           raise LoadYamlFromMustacheError, "Could not load config key '#{key}': #{e.message}"
         end

--- a/spec/lib/environment_config_transmogrifier_spec.rb
+++ b/spec/lib/environment_config_transmogrifier_spec.rb
@@ -63,6 +63,20 @@ describe EnvironmentConfigTransmogrifier do
       expect(new_config['properties']['parent_key']['child_key']['grandchild_key']).to eq 'bar'
     end
 
+    it 'should process mustache templates with new lines are kept' do
+      # Arrange
+      environment_templates = {
+        'properties.parent_key.child_key.grandchild_key' => '((MY_FOO_VAR))'
+      }
+      expect(ENV).to receive(:to_hash).and_return('MY_FOO_VAR' => "bar\nfoo")
+
+      # Act
+      new_config = EnvironmentConfigTransmogrifier.transmogrify(@base_config, environment_templates)
+
+      # Assert
+      expect(new_config['properties']['parent_key']['child_key']['grandchild_key']).to eq "bar\nfoo"
+    end
+
     it 'should keep value type' do
       # Arrange
       environment_templates = {


### PR DESCRIPTION
New line characters were being YAML loaded into spaces.  This provides
issues when loading configuration such as certs, keys, etc.. where the
standard format includes new line characters (0x10).