### PR TITLE
HCF-1122 Use BASH_SOURCE instead of GIT_ROOT to locate script dirs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,20 @@
 #!/usr/bin/env make
 
-GIT_ROOT:=$(shell git rev-parse --show-toplevel)
+# GNU make 3.81 or later required:
+ROOT_DIR:=$(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 
 .PHONY: lint test dist
 
 all: lint test dist
 
 test:
-	${GIT_ROOT}/make/test
+	${ROOT_DIR}make/test
 
 lint:
-	${GIT_ROOT}/make/lint
+	${ROOT_DIR}make/lint
 
 dist:
-	${GIT_ROOT}/make/package
+	${ROOT_DIR}make/package
 
 clean:
 	rm -rf output

--- a/make/include/darwin-support
+++ b/make/include/darwin-support
@@ -5,11 +5,12 @@ set -o errexit
 if [ "$(uname)" == "Darwin" ]; then
     DOCKER_RUNTIME=${DOCKER_RUNTIME:-'helioncf/hcf-pipeline-ruby-bosh'}
     GIT_ROOT=${GIT_ROOT:-$(git rev-parse --show-toplevel)}
+    WORK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
     docker run \
        --rm \
        --volume ${GIT_ROOT}:${GIT_ROOT} \
-       --workdir ${GIT_ROOT} \
+       --workdir ${WORK_DIR} \
        --entrypoint bash \
        ${DOCKER_RUNTIME} \
        -l -c "export RBENV_VERSION=2.1.7 && ${BASH_SOURCE[1]}"

--- a/make/lint
+++ b/make/lint
@@ -1,9 +1,9 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -o errexit
 
-GIT_ROOT=${GIT_ROOT:-$(git rev-parse --show-toplevel)}
-. ${GIT_ROOT}/make/include/darwin-support
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. ${SCRIPT_DIR}/include/darwin-support
 
 bundle package
 bundle exec rubocop --fail-level=error

--- a/make/package
+++ b/make/package
@@ -2,9 +2,9 @@
 
 set -o errexit
 
-GIT_ROOT=${GIT_ROOT:-$(git rev-parse --show-toplevel)}
-. ${GIT_ROOT}/make/include/darwin-support
-. ${GIT_ROOT}/make/include/versioning
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. ${SCRIPT_DIR}/include/darwin-support
+. ${SCRIPT_DIR}/include/versioning
 
 set -o errexit  # Unset by side-effect in sourced script
 

--- a/make/test
+++ b/make/test
@@ -1,9 +1,9 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -o errexit
 
-GIT_ROOT=${GIT_ROOT:-$(git rev-parse --show-toplevel)}
-. ${GIT_ROOT}/make/include/darwin-support
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. ${SCRIPT_DIR}/include/darwin-support
 
 bundle package
 bundle exec rspec "${@}"


### PR DESCRIPTION
GIT_ROOT doesn't work when the repo is a submodule (i.e. being built
as part of fissile).

GIT_ROOT is still being used for versioning. So when configgin is
being built as part of fissile, then the dist results will embed
the fissile version. This shouldn't really matter, as the version
isn't embedded inside the configgin software itself.